### PR TITLE
Offer access to inputs props (in particular: overridden events)

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -280,8 +280,11 @@ class ReactPhoneInput extends React.Component {
     });
   }
 
-  handleInputClick() {
+  handleInputClick(evt) {
     this.setState({showDropDown: false});
+    if (this.props.onClick) {
+      this.props.onClick(evt)
+    }
   }
 
   handleFlagItemClick(country) {

--- a/src/index.js
+++ b/src/index.js
@@ -468,6 +468,8 @@ class ReactPhoneInput extends React.Component {
     return (
       <div className="react-tel-input">
         <input
+          placeholder="+1 (702) 123-4567"
+          {...this.props}
           onChange={this.handleInput}
           onClick={this.handleInputClick}
           onFocus={this.handleInputFocus}
@@ -476,7 +478,7 @@ class ReactPhoneInput extends React.Component {
           ref="numberInput"
           type="tel"
           className={inputClasses}
-          placeholder="+1 (702) 123-4567"/>
+        />
         <div ref="flagDropDownButton" className={flagViewClasses} onKeyDown={this.handleKeydown} >
           <div ref='selectedFlag' onClick={this.handleFlagDropdownClick} className='selected-flag' title={`${this.state.selectedCountry.name}: + ${this.state.selectedCountry.dialCode}`}>
             <div className={inputFlagClasses}>

--- a/src/index.js
+++ b/src/index.js
@@ -310,10 +310,14 @@ class ReactPhoneInput extends React.Component {
     }
   }
 
-  handleInputFocus() {
+  handleInputFocus(evt) {
     // if the input is blank, insert dial code of the selected country
     if(ReactDOM.findDOMNode(this.refs.numberInput).value === '+') {
       this.setState({formattedNumber: '+' + this.state.selectedCountry.dialCode});
+    }
+
+    if (this.props.onFocus) {
+      this.props.onFocus(evt)
     }
   }
 

--- a/src/index.js
+++ b/src/index.js
@@ -391,6 +391,10 @@ class ReactPhoneInput extends React.Component {
     if(event.which === keys.ENTER) {
       this.props.onEnterKeyPress(event);
     }
+
+    if (this.props.onKeyDown) {
+      this.props.onKeyDown(event)
+    }
   }
 
   handleClickOutside() {

--- a/src/index.js
+++ b/src/index.js
@@ -545,7 +545,10 @@ ReactPhoneInput.propTypes = {
     defaultCountry: React.PropTypes.string,
     onlyCountries: React.PropTypes.arrayOf(React.PropTypes.string),
     preferredCountries: React.PropTypes.arrayOf(React.PropTypes.string),
-    onChange: React.PropTypes.func
+    onChange: React.PropTypes.func,
+    onFocus: React.PropTypes.func,
+    onClick: React.PropTypes.func,
+    onKeyDown: React.PropTypes.func
 };
 
 export default ReactPhoneInput;


### PR DESCRIPTION
Hi !

As we discussed in #7, I forward events handlers which are overridden if they exist.
Otherwise, I give the parent component complete access to the underlying input but I keep a control on the required props (like `ref`, `type` and necessary event handling).

That PR helps to make this component more compatible with the redux-form library.
