### PR TITLE
Fix bug when initial value starts with +

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -69,7 +69,7 @@ class ReactPhoneInput extends React.Component {
     let onlyCountries = excludeCountries(getOnlyCountries(props.onlyCountries), props.excludeCountries);
     let selectedCountryGuess = this.guessSelectedCountry(inputNumber.replace(/\D/g, ''), onlyCountries);
     let selectedCountryGuessIndex = findIndex(allCountries, selectedCountryGuess);
-    let dialCode = selectedCountryGuess && !startsWith(inputNumber, selectedCountryGuess.dialCode) ?
+    let dialCode = selectedCountryGuess && !startsWith(inputNumber.replace(/\D/g, ''), selectedCountryGuess.dialCode) ?
 			selectedCountryGuess.dialCode : '';
     let formattedNumber = this.formatNumber(dialCode + inputNumber.replace(/\D/g, ''), selectedCountryGuess ?
 			selectedCountryGuess.format : null);


### PR DESCRIPTION
Hello!

If I pass a value like this one:

`{ value: '+34 959 127 654' }`

The formattedNumber state is: `+34 349 591 27654`

With this small change fix this kind of situations.
