### PR TITLE
country-list z-index updated for list of phone inputs.

### DIFF
--- a/src/react-phone-input-style.less
+++ b/src/react-phone-input-style.less
@@ -802,7 +802,7 @@
   .country-list {
     list-style: none;
     position: absolute;
-    z-index: 2;
+    z-index: 15;
     padding: 0;
     margin: -1px 0 0 -1px;
     box-shadow: 1px 1px 4px rgba(0, 0, 0, 0.2);


### PR DESCRIPTION
![flaglist_confusion](https://cloud.githubusercontent.com/assets/523525/17558841/a6214578-5f24-11e6-959f-6afe4cf0cf63.gif)
When 2 or more phone input fields used vertically, flaglist dropdown does not overlay correctly. In order to solve this, style file needs to be updated.
