### PR TITLE
Fix for react 15.5.0+ PropTypes warning message 

### DIFF
--- a/package.json
+++ b/package.json
@@ -40,7 +40,8 @@
     "url-loader": "^0.5.7",
     "webpack": "^1.13.1",
     "webpack-dev-server": "^1.14.1",
-    "webpack-merge": "^0.13.0"
+    "webpack-merge": "^0.13.0",
+    "prop-types": "^15.5.8",
   },
   "dependencies": {
     "classnames": "^2.1.5"

--- a/src/index.js
+++ b/src/index.js
@@ -8,6 +8,7 @@ import React from 'react';
 import countryData from './country_data.js';
 import classNames from 'classnames';
 import ReactDOM from 'react-dom';
+import PropTypes from 'prop-types'
 
 let allCountries = countryData.allCountries;
 
@@ -569,15 +570,15 @@ ReactPhoneInput.defaultProps = {
 };
 
 ReactPhoneInput.propTypes = {
-    value: React.PropTypes.string,
-    autoFormat: React.PropTypes.bool,
-    defaultCountry: React.PropTypes.string,
-    onlyCountries: React.PropTypes.arrayOf(React.PropTypes.string),
-    preferredCountries: React.PropTypes.arrayOf(React.PropTypes.string),
-    onChange: React.PropTypes.func,
-    onFocus: React.PropTypes.func,
-    onClick: React.PropTypes.func,
-    onKeyDown: React.PropTypes.func
+    value: PropTypes.string,
+    autoFormat: PropTypes.bool,
+    defaultCountry: PropTypes.string,
+    onlyCountries: PropTypes.arrayOf(PropTypes.string),
+    preferredCountries: PropTypes.arrayOf(PropTypes.string),
+    onChange: PropTypes.func,
+    onFocus: PropTypes.func,
+    onClick: PropTypes.func,
+    onKeyDown: PropTypes.func
 };
 
 export default ReactPhoneInput;


### PR DESCRIPTION
"Accessing PropTypes via the main React package is deprecated. Use the prop-types package from npm instead."